### PR TITLE
Fix issue #1: Chapter 3 notebooks pdf error

### DIFF
--- a/chapter 3/GitHub Tracking Application/GitHub Sample Application - Part 2.ipynb
+++ b/chapter 3/GitHub Tracking Application/GitHub Sample Application - Part 2.ipynb
@@ -305,7 +305,8 @@
     }
    ],
    "source": [
-    "display(load_commit_activity(\"ibm-watson-data-lab\",\"pixiedust\")[\"pdf\"])"
+    "pdf = load_commit_activity(\"ibm-watson-data-lab\",\"pixiedust\")[\"pdf\"]\n",
+    "display(pdf)"
    ]
   },
   {

--- a/chapter 3/GitHub Tracking Application/GitHub Sample Application - Part 3.ipynb
+++ b/chapter 3/GitHub Tracking Application/GitHub Sample Application - Part 3.ipynb
@@ -153,7 +153,8 @@
     }
    ],
    "source": [
-    "display(load_commit_activity(\"ibm-watson-data-lab\",\"pixiedust\")[\"pdf\"])"
+    "pdf = load_commit_activity(\"ibm-watson-data-lab\",\"pixiedust\")[\"pdf\"]\n",
+    "display(pdf)"
    ]
   },
   {

--- a/chapter 3/GitHub Tracking Application/GitHub Sample Application - Part 4.ipynb
+++ b/chapter 3/GitHub Tracking Application/GitHub Sample Application - Part 4.ipynb
@@ -104,7 +104,8 @@
    },
    "outputs": [],
    "source": [
-    "display(load_commit_activity(\"ibm-watson-data-lab\",\"pixiedust\")[\"pdf\"])"
+    "pdf = load_commit_activity(\"ibm-watson-data-lab\",\"pixiedust\")[\"pdf\"]\n",
+    "display(pdf)"
    ]
   },
   {


### PR DESCRIPTION
When using the Chapter 3 notebooks:
GitHub Sample Application - Part 2.ipynb
GitHub Sample Application - Part 3.ipynb
GitHub Sample Application - Part 3.ipynb

The cell containing:
```python
display(load_commit_activity("ibm-watson-data-lab","pixiedust")["pdf"])
```
Results in this error:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-3e8155c0f313> in <module>()
----> 1 load_commit_activity('ibm-watson-data-lab','pixiedust',cell_id='1dd3de3332e142b9a1161b1d2a537648',nostore_pixiedust='true',aggregation='SUM',chartsize='100',handlerId='lineChart',keyFields='week',logx='false',logy='false',rendererId='bokeh',rowCount='500',valueFields='total',nostore_cw='1098',nostore_vh='978',showchrome='true',org_params='nostore_pixiedust',nostore_bokeh='false')

TypeError: load_commit_activity() got an unexpected keyword argument 'cell_id'
```
The solution is to split that statement like this:
```python
pdf = load_commit_activity("ibm-watson-data-lab","pixiedust")["pdf"]
display(pdf)
```